### PR TITLE
Fix partial initialization for MAR estimation

### DIFF
--- a/mavats/MAR.py
+++ b/mavats/MAR.py
@@ -130,11 +130,25 @@ def _initialize_AB(
     init_method: str = "proj",
 ) -> Tuple[np.ndarray, np.ndarray]:
     T, m, n = X.shape
-    if A_init is None or B_init is None:
+    if A_init is None and B_init is None:
         if init_method == "proj":
             A_init, B_init = _proj_estimate(X)
         elif init_method == "random":
             A_init = np.random.randn(m, m)
+            B_init = np.random.randn(n, n)
+        else:
+            raise ValueError('init_method must be either "proj" or "random"')
+    elif A_init is None:
+        if init_method == "proj":
+            A_init, _ = _proj_estimate(X)
+        elif init_method == "random":
+            A_init = np.random.randn(m, m)
+        else:
+            raise ValueError('init_method must be either "proj" or "random"')
+    elif B_init is None:
+        if init_method == "proj":
+            _, B_init = _proj_estimate(X)
+        elif init_method == "random":
             B_init = np.random.randn(n, n)
         else:
             raise ValueError('init_method must be either "proj" or "random"')

--- a/tests/test_MAR.py
+++ b/tests/test_MAR.py
@@ -85,6 +85,20 @@ def test_initialize_AB():
     assert B.shape == (n, n)
 
 
+def test_initialize_AB_partial():
+    T, m, n = 10, 3, 4
+    X = np.random.randn(T, m, n)
+    A_custom = np.ones((m, m))
+    A, B = _initialize_AB(X, A_custom, None)
+    assert np.allclose(A, A_custom)
+    assert B.shape == (n, n)
+
+    B_custom = np.ones((n, n))
+    A, B = _initialize_AB(X, None, B_custom)
+    assert np.allclose(B, B_custom)
+    assert A.shape == (m, m)
+
+
 def test_least_square_estimate():
     T, m, n = 10, 3, 4
     X = np.random.randn(T, m, n)


### PR DESCRIPTION
## Summary
- respect provided A or B initialization in `_initialize_AB`
- add regression tests for partial initialization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68460c3362f483338ef6c60efa109253